### PR TITLE
fix dark text over dark background - Monokai dark theme

### DIFF
--- a/schemes/Monokai dark.config
+++ b/schemes/Monokai dark.config
@@ -3,4 +3,4 @@
     background_image = None
     cursor_color = "#ffffff"
     foreground_color = "#f8f8f2"
-    palette = "#75715e:#f92672:#a6e22e:#f4bf75:#66d9ef:#ae81ff:#2aa198:#f9f8f5:#272822:#f92672:#a6e22e:#f4bf75:#66d9ef:#ae81ff:#2aa198:#f9f8f5"
+    palette = "#75715e:#f92672:#a6e22e:#f4bf75:#66d9ef:#ae81ff:#2aa198:#f9f8f5:#838383:#f92672:#a6e22e:#f4bf75:#66d9ef:#ae81ff:#2aa198:#f9f8f5"


### PR DESCRIPTION
Color 8 is unreadable since its color is exactly the same as the background's.

This commit changes it to a lighter grey color, making it readable.

Before:

![before](https://user-images.githubusercontent.com/925443/115386924-ec528580-a1d1-11eb-99be-7e01b8534ad9.png)

After: 

![after](https://user-images.githubusercontent.com/925443/115386932-eeb4df80-a1d1-11eb-9aa0-0b32ee195c30.png)